### PR TITLE
update markdown.codes renamed to LetsMarkdown.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ another simple single HTML page, server-less Markdown editor in JavaScript
 (web: [`hackmd.io`](http://hackmd.io/),
  github: [`HackMD`](https://github.com/hackmdio)) - Allows collaboration and more UI options. Link to Github is maintained. 
 
- **markdown.codes** 
-(web: [markdown.codes](https://markdown.codes),
-github: [Cveinnt/markdown.codes](https://github.com/Cveinnt/markdown.codes)) - 👨‍💻👩‍💻 Online collaborative markdown editing optimized for efficiency and ease of use.
+ **LetsMarkdown.com** 
+(web: [`LetsMarkdown.com`](https://letsmarkdown.com/),
+github: [`Cveinnt/LetsMarkdown.com`](https://github.com/Cveinnt/LetsMarkdown.com)) - 👨‍💻👩‍💻 Fast, minimal web editor that makes markdown editing collaborative and accessible to everyone.
 
 
 ## Markdown Desktop Editors


### PR DESCRIPTION
update to LetsMarkdown.com's new name, links, and description.

As the old links are dead and the same dev @Cveinnt has a new repo "LetsMarkdown.com", I assume the project got renamed.