### PR TITLE
Add section for editors for use in web app. Add Wysimark rich text editor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ another simple single HTML page, server-less Markdown editor in JavaScript
 github: [`Cveinnt/LetsMarkdown.com`](https://github.com/Cveinnt/LetsMarkdown.com)) - 👨‍💻👩‍💻 Fast, minimal web editor that makes markdown editing collaborative and accessible to everyone.
 
 
-## Markdown Editors for Integration in Web Apps
+## WYSIWYG Markdown Editors for Integration in Web Apps
 
 Editors designed to be used by developers for use in websites and web apps.
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,13 @@ another simple single HTML page, server-less Markdown editor in JavaScript
 github: [`Cveinnt/LetsMarkdown.com`](https://github.com/Cveinnt/LetsMarkdown.com)) - 👨‍💻👩‍💻 Fast, minimal web editor that makes markdown editing collaborative and accessible to everyone.
 
 
+## Markdown Editors for Integration in Web Apps
+
+Editors designed to be used by developers for use in websites and web apps.
+
+**Wysimark** (web: [`wysimark.com`](https://wysimark.com/), github: [`portive/wysimark`](https://github.com/portive/wysimark)) - The WYSIWYG editor for Markdown with integrations for React, Vue and Plain JavaScript. Supports CommonMark and GFM specs. Features tables, check lists, images, emojis and attachments. Comes with a modern interface and design. Features cloud based image uploads, attachments, and image resizing. MIT licensed.
+
+
 ## Markdown Desktop Editors
 
 ### Universal


### PR DESCRIPTION
I couldn't find a section for WYSIWYG markdown editors that are made for developers to integrate into their websites.

This is kind of like ProseMirror, CKEditor, Quill or TinyMCE but is saves and reads Markdown. Because it's WYSIWYG, it makes editing Markdown code accessible to users that are more comfortable with typical rich text editors or word processors.

Let me know if the wording is okay or this belongs elsewhere.