### PR TITLE
Remove unmaintained editors

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,0 +1,41 @@
+# Formerly Suggested Awesome Markdown Editors & (Pre)viewers
+
+## Markdown Online Editors
+
+*none*
+
+## WYSIWYG Markdown Editors for Integration in Web Apps
+
+Editors designed to be used by developers for use in websites and web apps.
+
+*none*
+
+## Markdown Desktop Editors
+
+### Universal
+
+*none*
+
+### Linux
+
+*none*
+
+### Microsoft Windows
+
+*none*
+
+### Apple Mac OS X
+
+*none*
+
+## Markdown Mobile Editors
+
+### Android
+
+*none*
+
+## Misc
+
+### WordPress
+
+*none*

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -21,6 +21,12 @@ Abricotine supports very good instant preview like Typora, but is open source - 
 The editor is unmaintained as of Jul 19, 2023. The author suggests using other editors.
 See https://github.com/brrd/abricotine/issues/347.
 
+[**Atom**](https://atom.io/) (FREE, open source)
+
+Markdown Preview - to be done
+
+The editor is archived and unmaintained as of Dec 15, 2022. See https://github.blog/2022-06-08-sunsetting-atom/.
+
 ### Linux
 
 *none*

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -14,7 +14,12 @@ Editors designed to be used by developers for use in websites and web apps.
 
 ### Universal
 
-*none*
+[**Abricotine**](https://github.com/brrd/Abricotine) (FREE, open source)
+
+Abricotine supports very good instant preview like Typora, but is open source - free forever.
+
+The editor is unmaintained as of Jul 19, 2023. The author suggests using other editors.
+See https://github.com/brrd/abricotine/issues/347.
 
 ### Linux
 

--- a/README.md
+++ b/README.md
@@ -77,10 +77,6 @@ Editors designed to be used by developers for use in websites and web apps.
 
 ### Universal
 
-[**Abricotine**](https://github.com/brrd/Abricotine) (FREE, open source)
-
-Abricotine supports very good instant preview like Typora, but is open source - free forever.
-
 [**Atom**](https://atom.io/) (FREE, open source)
 
 Markdown Preview - to be done

--- a/README.md
+++ b/README.md
@@ -77,10 +77,6 @@ Editors designed to be used by developers for use in websites and web apps.
 
 ### Universal
 
-[**Atom**](https://atom.io/) (FREE, open source)
-
-Markdown Preview - to be done
-
 [**Caret**](https://caret.io/) ($29 for continued use)
 
 Features live preview, files sidebar, go to anything, advanced spell checker and a lot more.


### PR DESCRIPTION
This PR removes two unmaintained editors from the list: Abriconite and Atom.

For further explanation, see the comments of the respective commits.