### PR TITLE
Add Ferrite - cross-platform Markdown editor built with Rust

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,12 @@ Deepdwn is an offline-only, feature-rich markdown editor for Windows, Mac and Li
 
 Supports image drag and drop, charts and diagrams, sheet music and tabs, table auto-formatting, tags and categories, and more.
 
+[**Ferrite**](https://getferrite.dev) (FREE, open source)
+
+Ferrite is a fast, lightweight Markdown editor built with Rust and egui for a native, responsive experience on Windows, Linux, and macOS. Features include WYSIWYG editing with live preview, native MermaidJS diagram rendering (11 diagram types), split view with dual editable panes, multi-format support (Markdown, JSON, CSV, YAML, TOML), Git integration with visual status indicators, semantic minimap, syntax highlighting for 100+ languages, 25+ color themes, multi-encoding file support, workspace mode with file tree and search, and Zen mode for distraction-free writing.
+
+[The code resides on GitHub](https://github.com/OlaProeis/Ferrite)
+
 [**GeekDown**](https://github.com/fearlessgeekmedia/geekdown). (FREE, open source)
 
 A free, open source, cross-platform Markdown editor based on Milkdown. It can also be used to export to HTML and PDF documents.


### PR DESCRIPTION
## Summary

Adding [Ferrite](https://getferrite.dev) to the Universal section of Markdown Desktop Editors.

## About Ferrite

Ferrite is a free, open-source Markdown editor built with Rust and egui, available for Windows, Linux, and macOS.

**Key features:**
- WYSIWYG editing with live preview
- Native MermaidJS diagram rendering (11 diagram types)
- Split view with dual editable panes
- Multi-format support (Markdown, JSON, CSV, YAML, TOML)
- Git integration with visual status indicators
- Semantic minimap for document navigation
- Syntax highlighting for 100+ languages
- 25+ syntax color themes
- Multi-encoding file support
- Workspace mode with file tree and search
- Zen mode for distraction-free writing

**Links:**
- Website: https://getferrite.dev
- GitHub: https://github.com/OlaProeis/Ferrite
- Latest release: v0.2.5.3

Thank you for maintaining this awesome list!