### PR TITLE
Move Markpad to Universal section

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,10 @@ KeenWrite simplifies using variables in documents. Variables are useful for char
 
 See the [tutorials]([https://www.youtube.com/watch?v=u_dFd6UhdV8](https://www.youtube.com/playlist?list=PLB-WIt1cZYLm1MMx2FBG9KWzPIoWZMKu_)) for details.
 
+[**Markpad**](https://markpad.sftwr.dev/) (FREE, open source)
+
+A Markdown equivalent to Notepad. A lightweight, performance-focused Markdown viewer and general text editor built with Tauri. It uses the Monaco editor engine to provide a native-feeling desktop experience with full support for GitHub formatting and LaTeX math. It's a fast and minimal application designed to be your default viewer for all `.md` files. Features real-time split view, syntax highlighting, Mermaid diagrams, command palette shortcuts and more. Available on macOS, Linux, and Windows.
+
 [**Splitmark**](https://splitmark.app/) (FREE, open source, Paid Syncing Option)
 
 A free, open-source CLI-based Markdown editor with a focus on speed and efficiency. It features a file explorer, live preview, keybindings, and a distraction-free mode. Splitmark is designed for users who prefer keyboard navigation and minimalistic interfaces. It offers a paid option for end-to-end encrypted cloud syncing across devices with access to a web editor.
@@ -266,10 +270,6 @@ More / Articles
 
 
 ### Microsoft Windows
-
-[**Markpad**](https://markpad.sftwr.dev/) (FREE, open source) - [`alecdotdev/Markpad`](https://github.com/alecdotdev/Markpad)
-
-A Markdown equivalent to Notepad. A lightweight, performance-focused Markdown viewer and editor built with Tauri. It uses the Monaco editor engine to provide a native-feeling desktop experience with full support for GitHub formatting and LaTeX math. It's a fast and minimal application designed to be your default viewer for all `.md` files.
 
 **WriteMonkey**
 (web: [`writemonkey.com`](http://writemonkey.com)) -


### PR DESCRIPTION
Moved [Markpad](https://github.com/alecdotdev/Markpad) from Windows-only to Universal now that it has builds for macOS and Linux!