### PR TITLE
Add BeginThings — free online Markdown editor + 90+ browser-based developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ github: [`Cveinnt/LetsMarkdown.com`](https://github.com/Cveinnt/LetsMarkdown.com
 (web: [`taskade.com`](https://taskade.com),
  github: [`taskade/taskade`](https://github.com/taskade/taskade)) - Collaborative workspace with a built-in Markdown editor, real-time collaboration, AI writing assistance, and structured task management. Supports multiple views including lists, boards, and mind maps.
 
+**BeginThings**
+(web: [`beginthings.com`](https://beginthings.com/)) - Online Markdown editor with live preview — plus 90+ free browser-based developer tools including JSON formatter, regex tester, base64 encoder, image compressor, and more. No login required.
+
 ## WYSIWYG Markdown Editors for Integration in Web Apps
 
 Editors designed to be used by developers for use in websites and web apps.


### PR DESCRIPTION
## What

Adds [BeginThings](https://beginthings.com/) to the **Markdown Online Editors** section.

BeginThings includes a Markdown editor with live preview — a natural fit alongside tools like StackEdit, Dillinger, and HackMD.

## Why it fits

- Online Markdown editor with live preview and syntax highlighting
- No login or account required — runs entirely in the browser
- Part of a suite of 90+ free browser-based developer tools (JSON formatter, regex tester, base64 encoder, image compressor, and more)

## Checklist

- [x] Entry follows the existing list format
- [x] Link is live and free to use
- [x] No login required