### PR TITLE
Update MDLook: fix GitHub username, remove stale license

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,8 +378,8 @@ More / Articles
 
 **MDLook**
 (web: [`mdlook.com`](https://mdlook.com),
- github: [`r1qdj0/MDLook`](https://github.com/r1qdj0/MDLook)) -
-Portable, fully offline Markdown editor for Windows. No install, no internet, no Electron — uses WebView2 at just 42 MB total. Features split-pane editing with live preview, dark mode, KaTeX math, Mermaid diagrams, syntax highlighting, and export to HTML. MIT licensed.
+ github: [`djosci/MDLook`](https://github.com/djosci/MDLook)) -
+Portable, fully offline Markdown editor for Windows. No install, no internet, no Electron — uses WebView2 at just 42 MB total. Features split-pane editing with live preview, dark mode, KaTeX math, Mermaid diagrams, syntax highlighting, and export to HTML.
 
 ### Apple Mac OS X
 


### PR DESCRIPTION
Two small fixes for the MDLook entry:

- GitHub username changed from `r1qdj0` to `djosci` (account rename)
- Removed "MIT licensed" (no longer accurate)