### PR TITLE
Add PDF2MD.pro to Upcoming (2026) Online Editors

### DIFF
--- a/UPCOMING.md
+++ b/UPCOMING.md
@@ -9,6 +9,9 @@ for Linux, Apple OS X, Microsoft Windows, the World Wide Web and more.
 
 ## Markdown Online Editors
 
+**PDF2MD.pro**
+(web: [`pdf2md.pro`](https://pdf2md.pro/)), - Free online PDF to Markdown converter with browser-based processing for full privacy. Supports batch conversion, smart formatting detection, and live preview.
+
 
 ## WYSIWYG Markdown Editors for Integration in Web Apps
 


### PR DESCRIPTION
Adding **PDF2MD.pro** to the Upcoming (2026) Markdown Online Editors section as requested in #134.

PDF2MD.pro is a free online PDF to Markdown converter with browser-based processing for full privacy. Supports batch conversion, smart formatting detection, and live preview.

- Website: https://pdf2md.pro/
- Free to use, no sign-up required
- All processing happens client-side

Thanks for the guidance on the new listing policy!