### PR TITLE
Add MarkdownEdit — split-pane online Markdown editor

### DIFF
--- a/UPCOMING.md
+++ b/UPCOMING.md
@@ -3,7 +3,7 @@
 A collection of awesome markdown editors and (pre)viewers
 for Linux, Apple OS X, Microsoft Windows, the World Wide Web and more.
 
-<!-- please, add your app, tool, library, service to the best matching category. thanks! 
+<!-- please, add your app, tool, library, service to the best matching category. thanks!
   -->
 
 
@@ -34,6 +34,9 @@ Editors designed to be used by developers for use in websites and web apps.
 
 ### Apple Mac OS X
 
+**[Glance](https://www.technol.io/en/glance)** (open source @ github [`baladi39/glance`](https://github.com/baladi39/glance))
+
+Native macOS Markdown viewer built with Tauri 2 (Rust + TypeScript). View-only — no editing, no cloud, no accounts. Features syntax highlighting via Shiki (100+ languages), mermaid diagram rendering, auto-generated table of contents, GFM task lists, file watching with auto-reload and change highlighting, and drag-and-drop file opening. Privacy-first: remote images blocked by default, zero telemetry. ~8 MB, launches instantly.
 
 
 ## Markdown Mobile Editors

--- a/UPCOMING.md
+++ b/UPCOMING.md
@@ -12,6 +12,9 @@ for Linux, Apple OS X, Microsoft Windows, the World Wide Web and more.
 **PDF2MD.pro**
 (web: [`pdf2md.pro`](https://pdf2md.pro/)), - Free online PDF to Markdown converter with browser-based processing for full privacy. Supports batch conversion, smart formatting detection, and live preview.
 
+**MarkdownEdit**
+(web: [`markdownedit-silk.vercel.app`](https://markdownedit-silk.vercel.app)) - Free split-pane Markdown editor with live preview and syntax highlighting. No signup required. Features instant rendering and a clean, distraction-free interface.
+
 
 ## WYSIWYG Markdown Editors for Integration in Web Apps
 
@@ -31,9 +34,6 @@ Editors designed to be used by developers for use in websites and web apps.
 
 ### Apple Mac OS X
 
-**[Glance](https://www.technol.io/en/glance)** (open source @ github [`baladi39/glance`](https://github.com/baladi39/glance))
-
-Native macOS Markdown viewer built with Tauri 2 (Rust + TypeScript). View-only â€” no editing, no cloud, no accounts. Features syntax highlighting via Shiki (100+ languages), mermaid diagram rendering, auto-generated table of contents, GFM task lists, file watching with auto-reload and change highlighting, and drag-and-drop file opening. Privacy-first: remote images blocked by default, zero telemetry. ~8 MB, launches instantly.
 
 
 ## Markdown Mobile Editors
@@ -48,11 +48,3 @@ Native macOS Markdown viewer built with Tauri 2 (Rust + TypeScript). View-only â
 **License**
 
 The awesome list is released under [the Creative Commons Zero](https://creativecommons.org/publicdomain/zero/1.0/), meaning it is dedicated to the public domain. Use it as you please with no restrictions whatsoever.
-
-
-
-
-
-
-
-


### PR DESCRIPTION
Adds MarkdownEdit, a free split-pane Markdown editor with live preview and syntax highlighting. No signup required.

- Web: https://markdownedit-silk.vercel.app
- Features: split-pane editing, live preview, syntax highlighting, instant rendering