### PR TITLE
Add Glance — native macOS Markdown viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,10 +403,6 @@ More / Articles
 Native macOS Markdown viewer (SwiftUI + WKWebView) with GitHub Flavored Markdown, Mermaid diagram rendering, syntax highlighting for 190+ languages, and a QuickLook extension for Finder preview.
 -->
 
-**[Glance](https://www.technol.io/en/glance)** (open source @ github [`baladi39/glance`](https://github.com/baladi39/glance))
-
-Native macOS Markdown viewer built with Tauri 2 (Rust + TypeScript). View-only — no editing, no cloud, no accounts. Features syntax highlighting via Shiki (100+ languages), mermaid diagram rendering, auto-generated table of contents, GFM task lists, file watching with auto-reload and change highlighting, and drag-and-drop file opening. Privacy-first: remote images blocked by default, zero telemetry. ~8 MB, launches instantly.
-
 [**mdnb**](https://mdnb.app) (FREE)
 
 mdnb is a free, native macOS app built in Swift (not Electron or Tauri). Files are stored as plain .mdfiles & support wikilinks, tags, task lists & mermaid diagrams. Full text search & a command palette make it easier than ever to find your notes. Over 20 built in themes make your notes look better than ever. Use Claude Code or Codex CLI in the built in Ghostty terminal. Sync your notes with git, iCloud or Google Drive.

--- a/README.md
+++ b/README.md
@@ -403,6 +403,10 @@ More / Articles
 Native macOS Markdown viewer (SwiftUI + WKWebView) with GitHub Flavored Markdown, Mermaid diagram rendering, syntax highlighting for 190+ languages, and a QuickLook extension for Finder preview.
 -->
 
+**[Glance](https://www.technol.io/en/glance)** (open source @ github [`baladi39/glance`](https://github.com/baladi39/glance))
+
+Native macOS Markdown viewer built with Tauri 2 (Rust + TypeScript). View-only — no editing, no cloud, no accounts. Features syntax highlighting via Shiki (100+ languages), mermaid diagram rendering, auto-generated table of contents, GFM task lists, file watching with auto-reload and change highlighting, and drag-and-drop file opening. Privacy-first: remote images blocked by default, zero telemetry. ~8 MB, launches instantly.
+
 [**mdnb**](https://mdnb.app) (FREE)
 
 mdnb is a free, native macOS app built in Swift (not Electron or Tauri). Files are stored as plain .mdfiles & support wikilinks, tags, task lists & mermaid diagrams. Full text search & a command palette make it easier than ever to find your notes. Over 20 built in themes make your notes look better than ever. Use Claude Code or Codex CLI in the built in Ghostty terminal. Sync your notes with git, iCloud or Google Drive.

--- a/UPCOMING.md
+++ b/UPCOMING.md
@@ -31,6 +31,9 @@ Editors designed to be used by developers for use in websites and web apps.
 
 ### Apple Mac OS X
 
+**[Glance](https://www.technol.io/en/glance)** (open source @ github [`baladi39/glance`](https://github.com/baladi39/glance))
+
+Native macOS Markdown viewer built with Tauri 2 (Rust + TypeScript). View-only — no editing, no cloud, no accounts. Features syntax highlighting via Shiki (100+ languages), mermaid diagram rendering, auto-generated table of contents, GFM task lists, file watching with auto-reload and change highlighting, and drag-and-drop file opening. Privacy-first: remote images blocked by default, zero telemetry. ~8 MB, launches instantly.
 
 
 ## Markdown Mobile Editors


### PR DESCRIPTION
## What is Glance?

[Glance](https://www.technol.io/en/glance) is a native macOS Markdown viewer built with [Tauri 2](https://v2.tauri.app) (Rust + TypeScript).

## Why add it?

macOS has no built-in Markdown renderer. Most apps in the Apple Mac OS X section are **editors** or **note-taking apps**. Glance is a **dedicated viewer** — it fills a different niche:

- **View-only** — no editing, purely for reading/previewing `.md` files
- **Privacy-first** — no cloud, no telemetry, remote images blocked by default
- **Native & lightweight** — ~8 MB, launches instantly
- **Syntax highlighting** — Shiki with 100+ languages
- **Mermaid diagrams** — renders mermaid code blocks
- **Table of contents** — auto-generated sidebar
- **File watching** — auto-reloads on change with diff highlighting

Added to the **Apple Mac OS X** section.

## Links

- Website: https://www.technol.io/en/glance