### PR TITLE
Add MarkViewer (Apple Mac OS X)

### DIFF
--- a/UPCOMING.md
+++ b/UPCOMING.md
@@ -46,6 +46,10 @@ Super clean, focused, native macOS Markdown editor. Think in markdown. Reason wi
 
 Native macOS Markdown viewer built with Tauri 2 (Rust + TypeScript). View-only — no editing, no cloud, no accounts. Features syntax highlighting via Shiki (100+ languages), mermaid diagram rendering, auto-generated table of contents, GFM task lists, file watching with auto-reload and change highlighting, and drag-and-drop file opening. Privacy-first: remote images blocked by default, zero telemetry. ~8 MB, launches instantly.
 
+**[MarkViewer](https://markviewer.com)** (Download @ github [`SeungbinBaik/markviewer-releases`](https://github.com/SeungbinBaik/markviewer-releases))
+
+Native macOS Markdown viewer and editor built with Tauri 2 (Rust + TypeScript). Browse any folder of Markdown files with tab-based navigation, auto-generated table of contents, syntax highlighting, Mermaid diagrams, GFM task lists, and footnotes. Switch into edit mode for in-place authoring with live preview, plus optional bring-your-own-key AI assistance for editing.
+
 
 ## Markdown Mobile Editors
 


### PR DESCRIPTION
## What

Adds MarkViewer to the **Apple Mac OS X** subsection of **Markdown Desktop Editors** in `UPCOMING.md`, per the 2026 staging policy.

## Why

Native macOS Markdown viewer + editor with a feature mix not currently represented in the section: viewer-first workflow with editing on the same surface, plus optional bring-your-own-key AI assistance.

- Homepage: https://markviewer.com
- Releases (GitHub): https://github.com/SeungbinBaik/markviewer-releases
- Built with Tauri 2 (Rust + TypeScript)

## Checklist

- [x] Added to UPCOMING.md per 2026 policy
- [x] Includes a GitHub link (releases repo)
- [x] One paragraph description matching the style of recent entries (Sly, Slate, Glance)
- [x] Placed under correct section (Markdown Desktop Editors → Apple Mac OS X)
- [x] No duplicate (searched existing entries)