### PR TITLE
Add qnote to Linux section

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,10 @@ a minimal markdown editor
 (github: [`TadavomnisT/MDEditor`](https://github.com/TadavomnisT/MDEditor)) -
 MDEditor is a free and open-source Markdown editor that supports previewing and exporting to HTML, PDF, MediaWiki, and more. It also provides programming APIs and can be used as a web application or a cross-platform desktop app.
 
+**qnote**
+(github: [`Omibranch/qnote`](https://github.com/Omibranch/qnote)) -
+Minimal frameless notepad for Linux with Markdown support, PDF export via Typst, OCR, and automatic version history. Built with Tauri 2 and Rust. Available on AUR.
+
 
 More / Articles
 

--- a/UPCOMING.md
+++ b/UPCOMING.md
@@ -28,6 +28,10 @@ Editors designed to be used by developers for use in websites and web apps.
 
 ### Linux
 
+**[qnote](https://github.com/Omibranch/qnote)** (open source @ github [`Omibranch/qnote`](https://github.com/Omibranch/qnote))
+
+Minimal frameless notepad for Linux built with Tauri 2 (Rust + TypeScript). Features Markdown editing with live preview, real PDF export via Typst, OCR via Tesseract, automatic version history with snapshots, dark/light themes, and custom fonts. Available on AUR.
+
 
 ### Microsoft Windows
 


### PR DESCRIPTION
## Summary

**qnote** is a minimal frameless notepad for Linux built with Tauri 2 and Rust.

**Key features:**
- Markdown editing with live preview
- PDF export via Typst (real PDF, not HTML wrapper)
- OCR support via Tesseract
- Automatic version history with snapshots
- Frameless window, dark/light themes
- Available on AUR

**Links:**
- GitHub: https://github.com/Omibranch/qnote
- AUR: https://aur.archlinux.org/packages/qnote

Fits the Linux section as a native, lightweight, open-source Markdown editor.