### PR TITLE
Add Markdown Writer to UPCOMING online editors

### DIFF
--- a/COMMERCIAL.md
+++ b/COMMERCIAL.md
@@ -3,3 +3,7 @@
 **[MacMD Viewer](https://macmdviewer.com)** ($19.99 one-time)
 
 Native macOS Markdown viewer in SwiftUI — read-only, pairs with your editor of choice. Renders GitHub Flavored Markdown via WKWebView, with Mermaid diagrams, syntax highlighting for 190+ languages, and a QuickLook extension (press Space on any `.md` file in Finder). Live file reload (~50ms refresh after disk write) makes it well-suited for previewing files written by AI agents like Claude Code, Cursor, or Copilot. 2 MB binary, native Apple Silicon, no Electron. macOS 14+.
+
+**[Markdown Writer](https://markdownwriter.com)** (Free)
+
+Free online markdown editor with live preview. Write GitHub-flavored markdown with syntax highlighting, KaTeX math, Mermaid diagrams, and PDF export, right in your browser.

--- a/UPCOMING.md
+++ b/UPCOMING.md
@@ -15,6 +15,7 @@ for Linux, Apple OS X, Microsoft Windows, the World Wide Web and more.
 **MarkdownEdit**
 (web: [`markdownedit-silk.vercel.app`](https://markdownedit-silk.vercel.app)) - Free split-pane Markdown editor with live preview and syntax highlighting. No signup required. Features instant rendering and a clean, distraction-free interface.
 
+
 ## WYSIWYG Markdown Editors for Integration in Web Apps
 
 Editors designed to be used by developers for use in websites and web apps.

--- a/UPCOMING.md
+++ b/UPCOMING.md
@@ -15,6 +15,9 @@ for Linux, Apple OS X, Microsoft Windows, the World Wide Web and more.
 **MarkdownEdit**
 (web: [`markdownedit-silk.vercel.app`](https://markdownedit-silk.vercel.app)) - Free split-pane Markdown editor with live preview and syntax highlighting. No signup required. Features instant rendering and a clean, distraction-free interface.
 
+**Markdown Writer**
+(web: [`markdownwriter.com`](https://markdownwriter.com)) - Free online markdown editor with live preview. Write GitHub-flavored markdown with syntax highlighting, KaTeX math, Mermaid diagrams, and PDF export — right in your browser. Also includes a markdown cheatsheet and HTML ↔ Markdown converters.
+
 
 ## WYSIWYG Markdown Editors for Integration in Web Apps
 

--- a/UPCOMING.md
+++ b/UPCOMING.md
@@ -15,10 +15,6 @@ for Linux, Apple OS X, Microsoft Windows, the World Wide Web and more.
 **MarkdownEdit**
 (web: [`markdownedit-silk.vercel.app`](https://markdownedit-silk.vercel.app)) - Free split-pane Markdown editor with live preview and syntax highlighting. No signup required. Features instant rendering and a clean, distraction-free interface.
 
-**Markdown Writer**
-(web: [`markdownwriter.com`](https://markdownwriter.com)) - Free online markdown editor with live preview. Write GitHub-flavored markdown with syntax highlighting, KaTeX math, Mermaid diagrams, and PDF export — right in your browser. Also includes a markdown cheatsheet and HTML ↔ Markdown converters.
-
-
 ## WYSIWYG Markdown Editors for Integration in Web Apps
 
 Editors designed to be used by developers for use in websites and web apps.


### PR DESCRIPTION
Adds **Markdown Writer** ([markdownwriter.com](https://markdownwriter.com)) to the "Markdown Online Editors" section in `UPCOMING.md`, per the 2026 policy noted in the README that new entries should land in `UPCOMING.md` first.

Markdown Writer is a free online markdown editor with live preview. It supports GitHub-flavored markdown with syntax highlighting, KaTeX math, Mermaid diagrams, and PDF export — all running in the browser. It also bundles a markdown  cheatsheet and HTML ↔ Markdown converters.