### PR TITLE
Add MDHero to UPCOMING.md (Universal)

### DIFF
--- a/UPCOMING.md
+++ b/UPCOMING.md
@@ -29,6 +29,10 @@ Editors designed to be used by developers for use in websites and web apps.
 
 Local-first note-taking app with Notion-style WYSIWYG editing for plain text and Markdown files, Obsidian-style philosophy for local files, a plugin system with AI/LLM plugin, custom themes, and optional encrypted vaults. No cloud, no account, no subscription. ~9 MB, built with Tauri + Rust, works on Windows, Mac, and Linux.
 
+**[MDHero](https://mdhero.app)** (open source @ github [`vaibhavuk-dev/mdhero`](https://github.com/vaibhavuk-dev/mdhero))
+
+Reading-first native Markdown viewer for macOS and Windows with a lightweight editor mode. Built with Tauri 2 + SvelteKit, ~8 MB — vs. 100-200 MB for Electron-based alternatives. Renders KaTeX math, Mermaid diagrams, and syntax-highlighted code via highlight.js (~25 languages). Features tab-based navigation with persisted edit state, table-of-contents sidebar, pinned project folders, Vim keybindings (j/k/gg/G), source-line scroll sync between viewer/raw/editor modes, Open URL fetcher for GitHub/GitLab/Bitbucket files, an LLM paste mode that auto-unescapes `\n` and `\"` from ChatGPT/Claude output, and an optional Close-on-Escape mode for file-manager viewer usage. Press Cmd+E to edit, Cmd+S to save. MIT licensed. No user tracking — anonymous update checks send only OS family and version.
+
 
 ### Linux
 


### PR DESCRIPTION
Adding **MDHero** — a free, open-source, native Markdown viewer for macOS and Windows.

- Site: https://mdhero.app
- Source: https://github.com/vaibhavuk-dev/mdhero
- License: MIT

Tauri 2 + SvelteKit, ~8 MB. Placed under the Universal section since it ships for both macOS and Windows, matching the Binderus precedent. Format follows the existing entries in that section.