### PR TITLE
Add Glyph (cross-platform Tauri markdown viewer/editor)

### DIFF
--- a/UPCOMING.md
+++ b/UPCOMING.md
@@ -21,6 +21,10 @@ for Linux, Apple OS X, Microsoft Windows, the World Wide Web and more.
 (web: [`binderus.com`](https://www.binderus.com), open source frontend @ github [`binderus/binderus`](https://github.com/binderus/binderus)) -
 Local-first note-taking app with Notion-style WYSIWYG editing for plain text and Markdown files, Obsidian-style philosophy for local files, a plugin system with AI/LLM plugin, custom themes, and optional encrypted vaults. No cloud, no account, no subscription. ~9 MB, built with Tauri + Rust, works on Windows, Mac, and Linux.
 
+**Glyph**
+(open source @ github [`hamidfzm/glyph`](https://github.com/hamidfzm/glyph)) -
+Cross-platform native Markdown viewer and editor built with Tauri 2 (Rust + React 19). Features GitHub Flavored Markdown, KaTeX math, Mermaid diagrams, wikilinks with backlinks, multi-file tabs, 6 syntax themes, AI summarization (Claude/OpenAI/Ollama), text-to-speech, and platform-native styling. Offline-first, MIT licensed. Works on macOS, Windows, and Linux.
+
 **MDHero**
 (web: [`mdhero.app`](https://mdhero.app)), open source @ github [`vaibhavuk-dev/mdhero`](https://github.com/vaibhavuk-dev/mdhero)) -
 Reading-first native Markdown viewer for macOS and Windows with a lightweight editor mode. Built with Tauri 2 + SvelteKit, ~8 MB — vs. 100-200 MB for Electron-based alternatives. Renders KaTeX math, Mermaid diagrams, and syntax-highlighted code via highlight.js (~25 languages). Features tab-based navigation with persisted edit state, table-of-contents sidebar, pinned project folders, Vim keybindings (j/k/gg/G), source-line scroll sync between viewer/raw/editor modes, Open URL fetcher for GitHub/GitLab/Bitbucket files, an LLM paste mode that auto-unescapes `\n` and `\"` from ChatGPT/Claude output, and an optional Close-on-Escape mode for file-manager viewer usage. Press Cmd+E to edit, Cmd+S to save. MIT licensed. No user tracking — anonymous update checks send only OS family and version.


### PR DESCRIPTION
Adds **Glyph** to UPCOMING.md under *Markdown Desktop Editors → Universal*, per the 2026 policy of listing new entries on the Upcoming page first.

Glyph is a free, open-source, cross-platform (macOS/Windows/Linux) native Markdown viewer and editor built with Tauri 2 + React 19, MIT licensed. Source: https://github.com/hamidfzm/glyph

Placed alphabetically after Binderus in the Universal section.