### PR TITLE
Add Huiyu MD - minimal Tauri-based Markdown reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,10 @@ Joplin is a free, open source note taking and to-do application, which can handl
 
 Octarine is a lightweight, privacy-focused markdown note-taking app built for speed and simplicity. At under 30MB, it offers a clean WYSIWYG editor and stores notes locally as plain markdown files, keeping your data entirely in your control. It features properties, views for displaying notes as tables, and optional AI integrations with multiple providers. Built with Tauri for fast, native performance on Mac, Windows, and Linux.
 
+[**Huiyu MD**](https://github.com/huiyu9144/Huiyu-MD) (FREE, open source)
+
+A minimal, lightning-fast Markdown reader for Windows & macOS. Built with Tauri 2.0 (Rust + React). Features dark/light themes, Ctrl+scroll zoom (25%-400%), KaTeX math formulas, code highlighting with copy button, drag & drop, and right-click context menu with Buy Me a Coffee. Only ~5MB, starts instantly, zero white flash.
+
 [**Stik**](https://stik.ink) (FREE, open source)
 
 Stik is an instant thought capture app for macOS. Press a global hotkey and a post-it note appears — type your thought, close it, done. Notes are stored as plain markdown files in `~/Documents/Stik/`, organized into folders. Built with Tauri 2.0 (Rust + React) for native performance. Features include semantic search via on-device NLP, markdown editing with live preview, and image support.

--- a/UPCOMING.md
+++ b/UPCOMING.md
@@ -25,7 +25,11 @@ Local-first note-taking app with Notion-style WYSIWYG editing for plain text and
 (open source @ github [`hamidfzm/glyph`](https://github.com/hamidfzm/glyph)) -
 Cross-platform native Markdown viewer and editor built with Tauri 2 (Rust + React 19). Features GitHub Flavored Markdown, KaTeX math, Mermaid diagrams, wikilinks with backlinks, multi-file tabs, 6 syntax themes, AI summarization (Claude/OpenAI/Ollama), text-to-speech, and platform-native styling. Offline-first, MIT licensed. Works on macOS, Windows, and Linux.
 
-**MDHero**
+****Huiyu MD**
+(open source @ github [huiyu9144/Huiyu-MD](https://github.com/huiyu9144/Huiyu-MD)) -
+Minimal, lightning-fast Markdown reader for Windows & macOS. Built with Tauri 2.0 (Rust + React). Features dark/light themes with auto-persist, Ctrl+scroll zoom (25%-400%), KaTeX math formula rendering, code blocks with syntax highlighting and one-click copy, drag & drop file opening, auto file association, and a right-click context menu. Only ~5 MB, starts instantly (< 0.3s), zero white flash. macOS builds are code-signed and notarized by Apple.
+
+MDHero**
 (web: [`mdhero.app`](https://mdhero.app)), open source @ github [`vaibhavuk-dev/mdhero`](https://github.com/vaibhavuk-dev/mdhero)) -
 Reading-first native Markdown viewer for macOS and Windows with a lightweight editor mode. Built with Tauri 2 + SvelteKit, ~8 MB — vs. 100-200 MB for Electron-based alternatives. Renders KaTeX math, Mermaid diagrams, and syntax-highlighted code via highlight.js (~25 languages). Features tab-based navigation with persisted edit state, table-of-contents sidebar, pinned project folders, Vim keybindings (j/k/gg/G), source-line scroll sync between viewer/raw/editor modes, Open URL fetcher for GitHub/GitLab/Bitbucket files, an LLM paste mode that auto-unescapes `\n` and `\"` from ChatGPT/Claude output, and an optional Close-on-Escape mode for file-manager viewer usage. Press Cmd+E to edit, Cmd+S to save. MIT licensed. No user tracking — anonymous update checks send only OS family and version.
 


### PR DESCRIPTION
## What does this PR do?

Adds [Huiyu MD](https://github.com/huiyu9144/Huiyu-MD) to the awesome markdown editors list.

## Why should this be included?

Huiyu MD is a **minimal, lightning-fast** Markdown reader built with Tauri 2.0 (Rust + React). Unlike Electron-based editors (~150-200MB), Huiyu MD is only **~5MB** and starts **instantly** with zero white flash.

### Key features:
- 🌙 Dark/Light themes (auto-persist)
- 🔍 Ctrl+scroll zoom (25% - 400%)
- 📐 KaTeX math formula support
- 💻 Code highlighting + copy button
- 🖱️ Drag & drop file opening
- 📁 Auto file association (.md/.txt)
- ☕ Buy Me a Coffee (WeChat/Alipay/PayPal)
- 🍎 macOS (Apple Silicon, notarized) + 🪟 Windows

### Screenshots

![Dark Mode](https://raw.githubusercontent.com/huiyu9144/Huiyu-MD/main/docs/screenshots/dark-context.jpg)

![Light Mode](https://raw.githubusercontent.com/huiyu9144/Huiyu-MD/main/docs/screenshots/light-context.jpg)

### Links
- GitHub: https://github.com/huiyu9144/Huiyu-MD
- Website: https://www.huiyu.ai
- Latest Release: https://github.com/huiyu9144/Huiyu-MD/releases/tag/v1.5.0