### PR TITLE
Add dochost to Markdown Online Editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ github: [`Cveinnt/LetsMarkdown.com`](https://github.com/Cveinnt/LetsMarkdown.com
 (web: [`taskade.com`](https://taskade.com),
  github: [`taskade/taskade`](https://github.com/taskade/taskade)) - Collaborative workspace with a built-in Markdown editor, real-time collaboration, AI writing assistance, and structured task management. Supports multiple views including lists, boards, and mind maps.
 
+**dochost**
+(web: [`dochost.io`](https://dochost.io/)), - Paste Markdown or HTML and instantly get a hosted, shareable link. Free with no signup, featuring a live Markdown preview and Markdown-to-HTML / HTML-to-URL hosting.
+
 ## WYSIWYG Markdown Editors for Integration in Web Apps
 
 Editors designed to be used by developers for use in websites and web apps.


### PR DESCRIPTION
Adds **dochost** ([dochost.io](https://dochost.io/)) under *Markdown Online Editors*.

dochost is a free, no-signup web tool: paste Markdown or HTML and instantly get a hosted, shareable link. It has a live Markdown preview and supports Markdown-to-HTML / HTML-to-URL hosting — similar in spirit to the other online editors and publish/host tools already in this section.

- Web: https://dochost.io/
- Format follows the existing `**Name** (web: ...) - description` convention, placed at the end of the Markdown Online Editors list.