### PR TITLE
Add MDXG Redline (Markdown Online (Pre)viewers)

### DIFF
--- a/UPCOMING.md
+++ b/UPCOMING.md
@@ -9,7 +9,9 @@ for Linux, Apple OS X, Microsoft Windows, the World Wide Web and more.
 
 ## Markdown Online Editors
 
-
+**MDXG Redline**
+(web: [`mkdn.review`](https://mkdn.review/?url=https%3A%2F%2Fraw.githubusercontent.com%2Foubakiou%2Fmdxg-redline%2Frefs%2Fheads%2Fmain%2FREADME.md), open source @ github [`oubakiou/mdxg-redline`](https://github.com/oubakiou/mdxg-redline)) -
+Read-only Markdown (pre)viewer with inline review comments, distributed as a single standalone HTML file (also runnable via `npx mdxg-redline`). Implements the MDXG Viewer profile: Word/Pages-style stacked virtual pages, page navigation and outline, in-document search, and left-hand WASD keyboard navigation. Renders Shiki syntax highlighting (~235 languages), Mermaid diagrams, KaTeX math, and GitHub Flavored Markdown footnotes, with smartphone support. Select any text range to leave a comment; comments export as structured JSON keyed by headingPath and sourceLine, so an LLM agent can apply each one back to the exact lines. The standalone/CLI build makes no network requests (CSP connect-src 'none'); an optional online edition at mkdn.review fetches Markdown from an allowlisted public raw URL via a `?url=` parameter. MIT licensed.
 
 
 


### PR DESCRIPTION
Adds MDXG Redline under Markdown Online Editors in UPCOMING.md (per the 2026 policy of listing new entries there first).

A note on the section: MDXG Redline is a read-only (pre)viewer rather than an editor. I put it under "Online Editors" since the list title is "Markdown Editors & (Pre)viewers" and there isn't a separate (pre)viewer section. Happy to move it if you'd prefer a different home.

- Source: https://github.com/oubakiou/mdxg-redline (MIT)
- Online: https://mkdn.review
- Live demo (the project's README rendered in MDXG Redline, showing Mermaid, KaTeX, footnotes, and stacked virtual pages): https://mkdn.review/?url=https%3A%2F%2Fraw.githubusercontent.com%2Foubakiou%2Fmdxg-redline%2Frefs%2Fheads%2Fmain%2FREADME.md

It's a single standalone HTML file (also runnable via `npx mdxg-redline`) implementing the MDXG Viewer profile, with inline commenting that exports structured JSON for LLM agents.
