### PR TITLE
Add PrettyMD to the Commercial Edition (Apple Mac OS X)

### DIFF
--- a/COMMERCIAL.md
+++ b/COMMERCIAL.md
@@ -27,6 +27,9 @@ no matter if the basic usage is free or you only have ads or such.
 
 ### Apple Mac OS X
 
+**PrettyMD**
+(web: [`prettymd.app`](https://prettymd.app)) ($19 one-time) - Simple, beautiful desktop app for reading and reviewing the Markdown your AI writes. Built for the `.md` files produced by AI tools like ChatGPT, Claude, and coding agents — clean typography, GitHub Flavored Markdown, and a calm reading view instead of raw text. One-time purchase, no subscription. Available for macOS (Apple Silicon) and Windows.
+
 **MacMD Viewer** 
 (web: [`macmdviewer.com`](https://macmdviewer.com)) ($19.99 one-time) - Native macOS Markdown viewer in SwiftUI — read-only, pairs with your editor of choice. Renders GitHub Flavored Markdown via WKWebView, with Mermaid diagrams, syntax highlighting for 190+ languages, and a QuickLook extension (press Space on any `.md` file in Finder). Live file reload (~50ms refresh after disk write) makes it well-suited for previewing files written by AI agents like Claude Code, Cursor, or Copilot. 2 MB binary, native Apple Silicon, no Electron. macOS 14+.
 


### PR DESCRIPTION
Adds **PrettyMD** (https://prettymd.app) to **COMMERCIAL.md** under *Markdown Desktop Editors → Apple Mac OS X*, following the 2026 policy that closed-source apps with no public source go on the Commercial Edition page. It sits alongside its direct peers already listed there (MacMD Viewer, MarkViewer, MDViewer, Slate).

PrettyMD is a paid ($19 one-time) app for reading and reviewing the Markdown that AI tools produce. Available for macOS (Apple Silicon) and Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
