### PR TITLE
Add md0 - free suite of online Markdown tools

### DIFF
--- a/COMMERCIAL.md
+++ b/COMMERCIAL.md
@@ -27,6 +27,13 @@ no matter if the basic usage is free or you only have ads or such.
 (web: [`md0.io`](https://md0.io)) - Free suite of online Markdown tools. Includes a live editor with split-pane preview, WYSIWYG editor, table editor, and a full set of converters (Markdown to HTML, PDF, DOCX, CSV, Excel), generators (table, README, TOC), and a formatter. No login required for any tool.
 
 
+## Markdown CMS
+
+
+**md0 CMS**
+(web: [`cms.md0.io`](https://cms.md0.io)) - GitHub-backed headless CMS for Markdown content. Connect any GitHub repository, define content collections with a schema builder, and edit Markdown files through a visual editor — changes commit directly to your repo. Built for static site generators (Next.js, Astro, Hugo, etc.). Free to use.
+
+
 ## Markdown Desktop Editors
 
 ### Apple Mac OS X

--- a/COMMERCIAL.md
+++ b/COMMERCIAL.md
@@ -23,6 +23,10 @@ no matter if the basic usage is free or you only have ads or such.
 (web: [`markdownedit-silk.vercel.app`](https://markdownedit-silk.vercel.app)) - Free split-pane Markdown editor with live preview and syntax highlighting. No signup required. Features instant rendering and a clean, distraction-free interface.
 
 
+**md0**
+(web: [`md0.io`](https://md0.io)) - Free suite of online Markdown tools. Includes a live editor with split-pane preview, WYSIWYG editor, table editor, and a full set of converters (Markdown to HTML, PDF, DOCX, CSV, Excel), generators (table, README, TOC), and a formatter. No login required for any tool.
+
+
 ## Markdown Desktop Editors
 
 ### Apple Mac OS X
@@ -46,6 +50,4 @@ Native macOS Markdown viewer and editor built with Tauri 2 (Rust + TypeScript). 
 **Slate**
 (web: [`slatemd.app`](https://www.slatemd.app), download @ github [`SlateMD`](https://github.com/Slatemd-App/slate-releases)) - 
 Super clean, focused, native macOS Markdown editor. Think in markdown. Reason with AI. Start with a folder of markdown files. Over time, AI turns it into a knowledge base that thinks with you. Slate keeps the structure intact. So when you bring AI into the loop, it actually understands what you wrote. Not just the words, but the shape of your thinking.
-
-
 


### PR DESCRIPTION
## What is md0?

**md0** (md0.io) is a free suite of online Markdown tools — no login required for any of them.

Since there is no public source code, I've added it to COMMERCIAL.md per the 2026 contribution policy.

### Added: Markdown Online Editors

**md0** — live editor with split-pane preview, WYSIWYG editor, table editor, and converters (Markdown to HTML, PDF, DOCX, CSV, Excel), generators (table, README, TOC), and a formatter.

### Added: Markdown CMS (new section)

**md0 CMS** (cms.md0.io) — GitHub-backed headless CMS for Markdown content. Connect any GitHub repository, define collections with a schema builder, and edit Markdown files through a visual WYSIWYG editor — changes commit directly to your repo. Built for static site generators (Next.js, Astro, Hugo, etc.).