### PR TITLE
Add markupmarkdown to Markdown Online Editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ _Zen Writing - leaving you alone with your thoughts and your words_
 
 ## Markdown Online Editors
 
+**markupmarkdown**
+(web: [`mumd.metavert.io`](https://mumd.metavert.io),
+ github: [`jonradoff/markupmarkdown`](https://github.com/jonradoff/markupmarkdown)) - "Google Docs for Markdown" — open-source collaborative editor and review tool for Markdown files: anchored comment threads, suggested changes with one-click apply, review states, document checks, GitHub round-trip (open any repo's `.md`, push edits back as a PR), plus an MCP server so AI agents can join the same review loop as humans.
+
 **Markvim**
 (web: [`markvim.xyz`](https://markvim.xyz),
  github: [`SantiagoBobrik/markvim`](https://github.com/SantiagoBobrik/markvim)) - A minimalist Markdown editor with built-in Vim keybindings, live preview, and shareable links.

--- a/README.md
+++ b/README.md
@@ -24,10 +24,6 @@ _Zen Writing - leaving you alone with your thoughts and your words_
 
 ## Markdown Online Editors
 
-**markupmarkdown**
-(web: [`mumd.metavert.io`](https://mumd.metavert.io),
- github: [`jonradoff/markupmarkdown`](https://github.com/jonradoff/markupmarkdown)) - "Google Docs for Markdown" — open-source collaborative editor and review tool for Markdown files: anchored comment threads, suggested changes with one-click apply, review states, document checks, GitHub round-trip (open any repo's `.md`, push edits back as a PR), plus an MCP server so AI agents can join the same review loop as humans.
-
 **Markvim**
 (web: [`markvim.xyz`](https://markvim.xyz),
  github: [`SantiagoBobrik/markvim`](https://github.com/SantiagoBobrik/markvim)) - A minimalist Markdown editor with built-in Vim keybindings, live preview, and shareable links.

--- a/UPCOMING.md
+++ b/UPCOMING.md
@@ -9,6 +9,11 @@ for Linux, Apple OS X, Microsoft Windows, the World Wide Web and more.
 
 ## Markdown Online Editors
 
+**markupmarkdown**
+(web: [`mumd.metavert.io`](https://mumd.metavert.io), open source @ github [`jonradoff/markupmarkdown`](https://github.com/jonradoff/markupmarkdown)) -
+"Google Docs for Markdown" — collaborative editor and review tool for Markdown files: anchored comment threads on any text selection, suggested changes with one-click apply, review states (approve / request changes), document checks, and GitHub round-trip (open any repo's `.md`, edit, push back as a PR). Includes an MCP server so AI agents can comment, suggest, and review through the same loop as humans. MIT licensed, built with Go + React.
+
+
 **MDXG Redline**
 (web: [`mkdn.review`](https://mkdn.review/?url=https%3A%2F%2Fraw.githubusercontent.com%2Foubakiou%2Fmdxg-redline%2Frefs%2Fheads%2Fmain%2FREADME.md), open source @ github [`oubakiou/mdxg-redline`](https://github.com/oubakiou/mdxg-redline)) -
 Read-only Markdown (pre)viewer with inline review comments, distributed as a single standalone HTML file (also runnable via `npx mdxg-redline`). Implements the MDXG Viewer profile: Word/Pages-style stacked virtual pages, page navigation and outline, in-document search, and left-hand WASD keyboard navigation. Renders Shiki syntax highlighting (~235 languages), Mermaid diagrams, KaTeX math, and GitHub Flavored Markdown footnotes, with smartphone support. Select any text range to leave a comment; comments export as structured JSON keyed by headingPath and sourceLine, so an LLM agent can apply each one back to the exact lines. The standalone/CLI build makes no network requests (CSP connect-src 'none'); an optional online edition at mkdn.review fetches Markdown from an allowlisted public raw URL via a `?url=` parameter. MIT licensed.


### PR DESCRIPTION
Adds [markupmarkdown](https://github.com/jonradoff/markupmarkdown) — an open-source (MIT) "Google Docs for Markdown": a collaborative web editor and review tool for `.md` files.

Highlights:
- Anchored comment threads on any text selection, with suggested changes and one-click apply
- Review states (approve / request changes) that gate pushing edits back
- GitHub round-trip: open any repo's Markdown file, edit, and push back as a PR
- Document checks (lint-style policies you define per doc or per index)
- MCP server built in, so AI agents can comment, suggest, and review through the same loop as humans

Live at https://mumd.metavert.io — entry follows the existing format in the Markdown Online Editors section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)