### PR TITLE
Add Oats to upcoming markdown editors

### DIFF
--- a/UPCOMING.md
+++ b/UPCOMING.md
@@ -110,7 +110,7 @@ Open-source local-first Markdown outliner for macOS. Everseq stores notes as ord
 
 **OATS**
 (web: [`ariso.ai`](https://ariso.ai), open source @ github [`ariso-ai/oats`](https://github.com/ariso-ai/oats)) -
-Open-source macOS menu bar meeting-notes app that records conversations, creates live transcripts with speaker labels, and generates Markdown notes and summaries. Runs through a free cloud backend or fully offline on Apple Silicon Macs. MIT licensed.
+Open-source local-first macOS meeting-notes app that records conversations, creates live transcripts with speaker labels, and generates Markdown notes and summaries. Runs through a free cloud backend or fully offline on Apple Silicon Macs. MIT licensed.
 
 
 ## Markdown Mobile Editors

--- a/UPCOMING.md
+++ b/UPCOMING.md
@@ -108,6 +108,10 @@ Minimal, native macOS Markdown editor with live preview — built with AppKit + 
 (open source @ github [`alkalim/Everseq`](https://github.com/alkalim/Everseq)) -
 Open-source local-first Markdown outliner for macOS. Everseq stores notes as ordinary `.md` files while adding block trees, page and block references, embeds, queries, backlinks, daily notes, and full-text search. Built with Swift, AppKit, and SwiftUI; AGPL-3.0 licensed.
 
+**OATS**
+(web: [`ariso.ai`](https://ariso.ai), open source @ github [`ariso-ai/oats`](https://github.com/ariso-ai/oats)) -
+Open-source macOS menu bar meeting-notes app that records conversations, creates live transcripts with speaker labels, and generates Markdown notes and summaries. Runs through a free cloud backend or fully offline on Apple Silicon Macs. MIT licensed.
+
 
 ## Markdown Mobile Editors
 


### PR DESCRIPTION
Adds Oats to the Upcoming Apple Mac OS X section. Oats is an open-source macOS meeting-notes app that generates Markdown notes and summaries from live transcripts, so this follows the repo's 2026 Upcoming placement policy.
