### PR TITLE
Add NoteLoom (local-first browser Markdown editor) to Upcoming / Online Editors

### DIFF
--- a/UPCOMING.md
+++ b/UPCOMING.md
@@ -19,6 +19,11 @@ for Linux, Apple OS X, Microsoft Windows, the World Wide Web and more.
 Read-only Markdown (pre)viewer with inline review comments, distributed as a single standalone HTML file (also runnable via `npx mdxg-redline`). Implements the MDXG Viewer profile: Word/Pages-style stacked virtual pages, page navigation and outline, in-document search, and left-hand WASD keyboard navigation. Renders Shiki syntax highlighting (~235 languages), Mermaid diagrams, KaTeX math, and GitHub Flavored Markdown footnotes, with smartphone support. Select any text range to leave a comment; comments export as structured JSON keyed by headingPath and sourceLine, so an LLM agent can apply each one back to the exact lines. The standalone/CLI build makes no network requests (CSP connect-src 'none'); an optional online edition at mkdn.review fetches Markdown from an allowlisted public raw URL via a `?url=` parameter. MIT licensed.
 
 
+**NoteLoom**
+(web: [`noteloom.cc`](https://noteloom.cc)) -
+Local-first Markdown workspace that runs in Chromium desktop browsers (Chrome, Edge) and opens a real folder on your computer with the File System Access API, reading and writing the actual `.md` files inside it with no upload and no account. Source, live, and reading views, plus a folder tree, tabs, quick open, full-text search, outline, tags, wikilinks, backlinks, and relative images. Follows CommonMark and GitHub Flavored Markdown (tables, task lists, strikethrough), and works offline once loaded. Free to use.
+
+
 
 ## Markdown Desktop Editors
 


### PR DESCRIPTION
Adds NoteLoom to `UPCOMING.md` under **Markdown Online Editors**, per the 2026 "add new entries to Upcoming first" policy.

NoteLoom is a local-first Markdown workspace that runs in Chromium desktop browsers (Chrome, Edge) and opens a real local folder with the File System Access API, reading and writing the actual `.md` files with no upload and no account (source / live / reading views, folder tree, full-text search, wikilinks, backlinks, CommonMark + GFM, works offline once loaded).

Note: NoteLoom is closed source, so it has no public repo link and belongs on the Commercial Edition (`COMMERCIAL.md`) page rather than the main README. Happy to move the entry there directly if you prefer.

- Website: https://noteloom.cc
- App: https://app.noteloom.cc
