### PR TITLE
Add Markdown Tools Editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ _Zen Writing - leaving you alone with your thoughts and your words_
 
 ## Markdown Online Editors
 
+**Markdown Tools Editor**
+(web: [`markdowntools.io/editor`](https://www.markdowntools.io/editor)) - Free online Markdown editor with live preview, syntax highlighting, KaTeX math, and Mermaid diagrams; runs entirely in the browser, no signup required.
+
 **Markvim**
 (web: [`markvim.xyz`](https://markvim.xyz),
  github: [`SantiagoBobrik/markvim`](https://github.com/SantiagoBobrik/markvim)) - A minimalist Markdown editor with built-in Vim keybindings, live preview, and shareable links.


### PR DESCRIPTION
Adds [Markdown Tools Editor](https://www.markdowntools.io/editor) to the Markdown Online Editors section.

- Free online editor with live preview, syntax highlighting, KaTeX math, and Mermaid diagrams
- Runs entirely in the browser — no signup, files never leave the device
- Web-only entry following the existing format (e.g. JekyllPad), placed at the top of the section alongside the other recent additions
