### PR TITLE
docs: add Bangle.io to online editors

### DIFF
--- a/UPCOMING.md
+++ b/UPCOMING.md
@@ -9,6 +9,11 @@ for Linux, Apple OS X, Microsoft Windows, the World Wide Web and more.
 
 ## Markdown Online Editors
 
+**Bangle.io**
+(web: [`app.bangle.io`](https://app.bangle.io/), open source @ github [`bangle-io/bangle-io`](https://github.com/bangle-io/bangle-io)) -
+Local-first WYSIWYG note-taking that keeps your notes as portable Markdown. No account required.
+
+
 **markupmarkdown**
 (web: [`mumd.metavert.io`](https://mumd.metavert.io), open source @ github [`jonradoff/markupmarkdown`](https://github.com/jonradoff/markupmarkdown)) -
 "Google Docs for Markdown" — collaborative editor and review tool for Markdown files: anchored comment threads on any text selection, suggested changes with one-click apply, review states (approve / request changes), document checks, and GitHub round-trip (open any repo's `.md`, edit, push back as a PR). Includes an MCP server so AI agents can comment, suggest, and review through the same loop as humans. MIT licensed, built with Go + React.

--- a/UPCOMING.md
+++ b/UPCOMING.md
@@ -11,7 +11,7 @@ for Linux, Apple OS X, Microsoft Windows, the World Wide Web and more.
 
 **Bangle.io**
 (web: [`app.bangle.io`](https://app.bangle.io/), open source @ github [`bangle-io/bangle-io`](https://github.com/bangle-io/bangle-io)) -
-Local-first WYSIWYG note-taking that keeps your notes as portable Markdown. No account required.
+A simple yet powerful Markdown-based note-taking app with WYSIWYG editing and local-first storage.
 
 
 **markupmarkdown**


### PR DESCRIPTION
## Summary

- add Bangle.io at the top of the Markdown Online Editors section
- link the web app and open-source repository
- describe its local-first WYSIWYG experience in one concise line

## Validation

- `git diff --check`
- verified both links return HTTP 200
