### PR TITLE
Add Text to Confluence to commercial online editors

### DIFF
--- a/COMMERCIAL.md
+++ b/COMMERCIAL.md
@@ -6,6 +6,8 @@ no matter if the basic usage is free or you only have ads or such.
 
 
 ## Markdown Online Editors
+**Text to Confluence**
+(web: [`texttoconfluence.com`](https://www.texttoconfluence.com/)) - Free browser-based editor for preparing plain text and Markdown as Confluence-ready rich text.
 
 
 **Markdown Writer**


### PR DESCRIPTION
Adds Text to Confluence to the commercial online editor list. It is a free browser-based editor with a Confluence-specific workflow.

- Live demo: https://www.texttoconfluence.com/
- Public project hub: https://github.com/MakermingOne/texttoconfluence
