### PR TITLE
Add Markdown Tools (markdowntools.io) to Commercial online editors

### DIFF
--- a/COMMERCIAL.md
+++ b/COMMERCIAL.md
@@ -26,6 +26,9 @@ no matter if the basic usage is free or you only have ads or such.
 **md0**
 (web: [`md0.io`](https://md0.io)) - Free suite of online Markdown tools. Includes a live editor with split-pane preview, WYSIWYG editor, table editor, and a full set of converters (Markdown to HTML, PDF, DOCX, CSV, Excel), generators (table, README, TOC), and a formatter. No login required for any tool.
 
+**Markdown Tools**
+(web: [`markdowntools.io`](https://www.markdowntools.io)) - Free browser suite for Markdown: live editor, Markdown to PDF, PDF to Markdown, Markdown to HTML, table generator, plus Word and README helpers. No signup required.
+
 
 ## Markdown CMS
 

--- a/UPCOMING.md
+++ b/UPCOMING.md
@@ -25,6 +25,11 @@ Read-only Markdown (pre)viewer with inline review comments, distributed as a sin
 
 
 
+
+**Markdown Tools**
+(web: [`markdowntools.io`](https://www.markdowntools.io); commercial / no public source — also listed in COMMERCIAL.md) - Free browser Markdown suite: editor, Markdown↔PDF, Markdown to HTML, table generator, Word and README tools. No signup.
+
+
 ## Markdown Desktop Editors
 
 ### Editor Plugins


### PR DESCRIPTION
## Summary
Adds **Markdown Tools** (https://www.markdowntools.io) to `COMMERCIAL.md` under Markdown Online Editors, and a short matching note in `UPCOMING.md` per the 2026 new-entry policy.

## Why Commercial Edition
No public source repo is available for this site, so it belongs on the Commercial Edition page (same pattern as md0 and other free-with-no-source web tools).

## Fit
- Free browser Markdown suite: live editor, Markdown to PDF, PDF to Markdown, Markdown to HTML, table generator, Word and README helpers
- No signup required
- Distinct from the existing open-source desktop “Markdown Tools” (igormironchik) already listed in README.md
- Similar category neighbors: md0, Markdown Writer, MarkdownEdit

## Affiliation
I am the creator/operator of markdowntools.io (Wayde Lyle / @waydelyle).

## Checklist
- [x] Added to UPCOMING.md first (2026 policy)
- [x] Commercial / no public source → COMMERCIAL.md
- [x] Not a duplicate of markdowntools.io (only the unrelated OSS desktop app is listed)